### PR TITLE
gog: add Trails in the Sky 1-3

### DIFF
--- a/gamefixes-gog/ulwgl-251150.py
+++ b/gamefixes-gog/ulwgl-251150.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/251150.py

--- a/gamefixes-gog/ulwgl-251290.py
+++ b/gamefixes-gog/ulwgl-251290.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/251290.py

--- a/gamefixes-gog/ulwgl-436670.py
+++ b/gamefixes-gog/ulwgl-436670.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/436670.py

--- a/gamefixes-steam/251150.py
+++ b/gamefixes-steam/251150.py
@@ -1,0 +1,12 @@
+""" Game fix for The Legend of Heroes: Trails in the Sky
+"""
+# pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ """
+    util.protontricks('quartz') # Cutscene fixes
+    util.protontricks('amstream')
+    util.protontricks('lavfilters')
+    util.winedll_override('dinput8', 'n,b') # Set for the SoraVoice mod

--- a/gamefixes-steam/251290.py
+++ b/gamefixes-steam/251290.py
@@ -1,0 +1,12 @@
+""" Game fix for The Legend of Heroes: Trails in the Sky SC
+"""
+# pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ """
+    util.protontricks('quartz') # Cutscene fixes
+    util.protontricks('amstream')
+    util.protontricks('lavfilters')
+    util.winedll_override('dinput8', 'n,b') # Set for the SoraVoice mod

--- a/gamefixes-steam/436670.py
+++ b/gamefixes-steam/436670.py
@@ -1,0 +1,12 @@
+""" Game fix for The Legend of Heroes: Trails in the Sky the 3rd
+"""
+# pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ """
+    util.protontricks('quartz') # Cutscene fixes
+    util.protontricks('amstream')
+    util.protontricks('lavfilters')
+    util.winedll_override('dinput8', 'n,b') # Set for the SoraVoice mod


### PR DESCRIPTION
Adds the cutscene fix for The Legend of Heroes: Trails in the Sky 1-3, and preps for the [SoraVoice mod](https://www.pcgamingwiki.com/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky#Add_Voice_Acting). If 'non-essential' changes aren't desired, I can remove that from the commit.

What's the consensus on these sorts of changes where the game can work without the change, but it's probably going to be done by the player anyway? (Assuming it doesn't inadvertently affect the game for people that don't install the mod.)