### PR TITLE
gog: Add Soldier of Fortune II

### DIFF
--- a/gamefixes-gog/ulwgl-1228964594.py
+++ b/gamefixes-gog/ulwgl-1228964594.py
@@ -1,0 +1,12 @@
+""" Game fix for Soldier of Fortune II: Double Helix - Gold Edition 
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ """
+
+    # Fix display issues
+    util.set_environment('MESA_EXTENSION_MAX_YEAR', '2003')
+    util.set_environment('__GL_ExtensionStringVersion', '17700')


### PR DESCRIPTION
Adds the GOG version of SoF II with a display fix.