### PR TITLE
Add fix for They Are Billions

### DIFF
--- a/gamefixes-gog/ulwgl-644930.py
+++ b/gamefixes-gog/ulwgl-644930.py
@@ -1,0 +1,1 @@
+../gamefixes-steam/644930.py

--- a/gamefixes-steam/644930.py
+++ b/gamefixes-steam/644930.py
@@ -1,0 +1,9 @@
+""" They Are Billions
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    # fix broken or missing font in UI
+    util.protontricks("gdiplus")


### PR DESCRIPTION
Example with no changes:
![image](https://github.com/Open-Wine-Components/ULWGL-protonfixes/assets/36563538/eac0d183-78e1-49e9-ae61-f18e389622f7)

with `gdiplus` fix:
![withFix](https://github.com/Open-Wine-Components/ULWGL-protonfixes/assets/36563538/3aed5057-3d02-4e81-81c5-a2d36ba8bdc0)
