### PR TITLE
Grim Dawn: fix black screen

### DIFF
--- a/gamefixes-steam/219990.py
+++ b/gamefixes-steam/219990.py
@@ -13,3 +13,6 @@ def main():
     # Fixes the startup process.
     if os.path.isfile(os.path.join(os.getcwd(), 'GrimInternals64.exe')):
         util.replace_command('Grim Dawn.exe', 'GrimInternals64.exe')
+
+    # Fixes a black screen being rendered:
+    util.protontricks('d3dcompiler_43')


### PR DESCRIPTION
Add `d3dcompiler_43` to fix a black screen being rendered (making the game unplayable).