### PR TITLE
star citizen fixes

### DIFF
--- a/gamefixes-ulwgl/ulwgl-starcitizen.py
+++ b/gamefixes-ulwgl/ulwgl-starcitizen.py
@@ -2,11 +2,30 @@
 """
 #pylint: disable=C0103
 
-from protonfixes import util
 import os
+from protonfixes import util # pylint: disable=E0401
+from protonfixes.logger import log
 
 def main():
     """ EAC Workaround
     """
-    util.set_environment('SteamGameId','starcitizen')
 
+    #eac workaround
+    util.set_environment('EOS_USE_ANTICHEATCLIENTNULL','1')
+
+    #override for white/black launcher
+    util.winedll_override('libglesv2', 'builtin')
+    #override for nvidia cards
+    util.winedll_override('nvapi,nvapi64', 'disabled')
+    #allow the RSI Launcher to auto-update itself
+    util.winedll_override('powershell.exe', 'disabled')
+
+    environments = ["LIVE","PTU","EPTU","TECH-PREVIEW"]
+
+    for env in environments:
+        #launcher fails to create these directories in wine so create them here instead
+        #https://github.com/starcitizen-lug/knowledge-base/wiki#game-updates
+        envPath = os.path.join(util.protonprefix(), "drive_c","Program Files", "Roberts Space Industries", "StarCitizen", env)
+        if not os.path.exists(envPath):
+            os.makedirs(envPath)
+            log("created " + envPath)


### PR DESCRIPTION
Star Citizen has updated to a newer version of the EAC SDK, the client workaround can now be:

`EOS_USE_ANTICHEATCLIENTNULL=1`  instead of the game-specific hosts patch invoked with `SteamGameId=starcitizen`

create game directories that the RSI Launcher is not able to create for itself