### PR TITLE
steam: Add Dirt 3 Complete Edition fix.

### DIFF
--- a/gamefixes-steam/321040.py
+++ b/gamefixes-steam/321040.py
@@ -1,0 +1,11 @@
+""" Game fix for Dirt 3 Complete Edition
+"""
+
+from protonfixes import util
+
+
+def main():
+    """ installs openal as redistributable install script is borked.
+    """
+
+    util.protontricks('openal')


### PR DESCRIPTION
This fixes launch issues I've seen with DiRT3 with Proton >7

Turns out the included redistributables are not installed as they are supposed to be on first launch, so the game fails to find OpenAL32.dll and dies.

Let me know if any other files need to be made. 
~~I wasn't sure if I should stick a symlink to `321040.py` in `gamefixes-ulwgl` or not.~~ (Seeing as this game is only available on Steam, there's no need for a ulwgl gamefix symlink to be made.. I think)