### PR TITLE
add proton fix for S.T.A.L.K.E.R.: Clear Sky

### DIFF
--- a/gamefixes-steam/20510.py
+++ b/gamefixes-steam/20510.py
@@ -8,8 +8,10 @@ def main():
     """ installs d3dcomp43, d3dcomp46, d3dcomp47, directplay
     """
 
-    # Discord report in #proton-gaming from @thebigboo_
+    # from Discord report in #proton-gaming by @thebigboo_ 
+    # fix crashing from d3d comp errors
     util.protontricks('d3dcompiler_43')
     util.protontricks('d3dcompiler_46')
     util.protontricks('d3dcompiler_47')
+    # fixes multiplayer
     util.protontricks('directplay')

--- a/gamefixes-steam/20510.py
+++ b/gamefixes-steam/20510.py
@@ -1,0 +1,15 @@
+""" Game fix for S.T.A.L.K.E.R.: Clear Sky
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ installs d3dcomp43, d3dcomp46, d3dcomp47, directplay
+    """
+
+    # Discord report in #proton-gaming from @thebigboo_
+    util.protontricks('d3dcompiler_43')
+    util.protontricks('d3dcompiler_46')
+    util.protontricks('d3dcompiler_47')
+    util.protontricks('directplay')


### PR DESCRIPTION
filing this for user thebigboo_ in #proton-gaming, who confirmed the game works on standard proton but not on GE right now. this fixes d3d comp errors and multiplayer.