### PR TITLE
Grim Dawn: remove unsupported mod

### DIFF
--- a/gamefixes-steam/219990.py
+++ b/gamefixes-steam/219990.py
@@ -3,7 +3,6 @@
 #pylint: disable=C0103
 
 from protonfixes import util
-import os
 
 def main():
     # Fix black screen. Needed for the expansions, not for the base game:

--- a/gamefixes-steam/219990.py
+++ b/gamefixes-steam/219990.py
@@ -6,9 +6,5 @@ from protonfixes import util
 import os
 
 def main():
-    # Run script extender if it exists:
-    if os.path.isfile(os.path.join(os.getcwd(), 'GrimInternals64.exe')):
-        util.replace_command('Grim Dawn.exe', 'GrimInternals64.exe')
-
     # Fix black screen. Needed for the expansions, not for the base game:
     util.protontricks('d3dcompiler_43')


### PR DESCRIPTION
I have investigated and "Grim Internals" is a mod currently unsupported. It does not work anymore on newer versions of the game. For people that want to run it on older versions though, they can just select the executable manually.

Source of the information: https://forums.crateentertainment.com/t/tool-grim-internals/38773/7428