### PR TITLE
fix linting error

### DIFF
--- a/gamefixes-steam/409090.py
+++ b/gamefixes-steam/409090.py
@@ -12,7 +12,7 @@ import shutil
 from protonfixes import util
 
 def main():
-    syswow64 = os.path.join(util.protonprefix(), 'drive_c/windows/syswow64', 'dgvoodoo.conf')
+    syswow64 = os.path.join(util.protonprefix(), 'drive_c/windows/syswow64')
     if util.protontricks('dgvoodoo2'):
-        subprocess.call([f"sed -i '/[DirectX]/ {{/Resolution/s/max/unforced/}}' {syswow64}"], shell=True)
+        subprocess.call([f"sed -i '/[DirectX]/ {{/Resolution/s/max/unforced/}}' {syswow64}/dgvoodoo.conf"], shell=True)
     shutil.copy(os.path.join(syswow64, 'dgd3d9.dll'),os.path.join(syswow64, 'd3d9.dll'))


### PR DESCRIPTION
syswow64 = os.path.join(util.protonprefix(), 'drive_c/windows/syswow64', 'dgvoodoo.conf')

in https://github.com/Open-Wine-Components/ULWGL-protonfixes/pull/43 for some protonfixes the name of the file was added to syswow64 and it's fine but in this case syswow64 dir is used with another file so:

shutil.copy(os.path.join(syswow64, 'dgd3d9.dll'),os.path.join(syswow64, 'd3d9.dll'))
is drive_c/windows/syswow64/dgvoodoo.conf/d3d9.dll instead of drive_c/windows/syswow64/d3d9.dll 

@R1kaB3rN is this done automatically when the protonfix is linted or was this manual?

If it was manual it was a mistake there's no problem, but if it was automatic there's something wrong and maybe there are more protonfixes affected.

i guess it was manual because it wasn't modified now.