### PR TITLE
klite: update version to 18.1.5

### DIFF
--- a/verbs/klite.verb
+++ b/verbs/klite.verb
@@ -1,12 +1,12 @@
 w_metadata klite dlls \
     title="K-Lite codecs" \
     media="download" \
-    file1="K-Lite_Codec_Pack_1700_Basic.exe" \
+    file1="K-Lite_Codec_Pack_1815_Basic.exe" \
     homepage="https://codecguide.com/download_kl.htm"
 
 load_klite()
 {
-    w_download https://files3.codecguide.com/K-Lite_Codec_Pack_1700_Basic.exe 24ffa374926004d3b7e8e0a3daa2d0f7f18846c8bcbcbddf8af38a7f9a0fb629
+    w_download https://files3.codecguide.com/K-Lite_Codec_Pack_1815_Basic.exe 9eba61163d4ff3c0ce3e88aa21b15366757a260684d6190a271fc452ba05e7d7
     w_try_cd "${W_CACHE}/${W_PACKAGE}"
     cat > "klcp_basic_unattended.ini" <<_EOF_
 [Setup]
@@ -40,5 +40,5 @@ hwa_other_auto=1
 lang_set_preferred=1
 lang_autodetect=1
 _EOF_
-    w_try "${WINE}" start.exe /exec K-Lite_Codec_Pack_1700_Basic.exe /verysilent /norestart /LoadInf="./klcp_basic_unattended.ini"
+    w_try "${WINE}" start.exe /exec K-Lite_Codec_Pack_1815_Basic.exe /verysilent /norestart /LoadInf="./klcp_basic_unattended.ini"
 }


### PR DESCRIPTION
Please verify if installation & runtime of the verb still works for the updated version ([changelog](https://codecguide.com/changelogs_basic.htm)) before merging, previously (https://github.com/GloriousEggroll/protonfixes/pull/80) I could test this with Persona 4 Golden but that game doesn't need it anymore and the obsolete gamefix has corrently been [removed](https://github.com/GloriousEggroll/protonfixes/pull/113) in the past. 