### PR TITLE
Evaluate the returncode of the Winetricks process

### DIFF
--- a/util.py
+++ b/util.py
@@ -285,6 +285,12 @@ def protontricks(verb):
             process.wait()
             _killhanging()
 
+            # Check if the verb failed (eg. access denied)
+            retc = process.returncode
+            if retc != 0:
+                log.warn(f'Winetricks failed running verb "{verb}" with status {retc}.')
+                return False
+
             # Check if verb recorded to winetricks log
             if not checkinstalled(verb):
                 log.warn('Not recorded as installed: winetricks ' + verb + ', forcing!')


### PR DESCRIPTION
A failed Winetricks call is just interpreted as "forced" currently.
There is no mechanism to rerun them, for example after the verb was updated / fixed.

The current behavior might be intentional, I just ran into exactly this situation.